### PR TITLE
Removed Filter object payload from "Product listing" API call

### DIFF
--- a/src/page/products/index.jsx
+++ b/src/page/products/index.jsx
@@ -25,11 +25,11 @@ export default function Products() {
       order: "DESC",
       sortBy: "CREATED_DATE",
       filter: JSON.stringify({
-        title: "variants",
-        sku: "sku",
-        status: "DRAFT",
-        productType: "DIGITAL",
-        tag: "fsdds",
+        // title: "variants",
+        // sku: "sku",
+        // status: "DRAFT",
+        // productType: "DIGITAL",
+        // tag: "fsdds",
       }),
     };
     dispatch(fetchProducts(params));


### PR DESCRIPTION
Removed Filter object payload from "Product listing" API call, to get all products.